### PR TITLE
fix: bump-version workflow creates pull request

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -39,18 +39,12 @@ jobs:
           replace: "${{ steps.new_version.outputs.substring }}"
           include: "{*/{CMakeLists.txt,package.xml,setup.py},docker-compose*.yml}"
 
-      - name: Update tag
-        run: |
-          git config --local user.name "github-actions[bot]"
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git commit -a -m "build: bump version to ${{ steps.new_version.outputs.substring }} from ${{ steps.current_version.outputs.substring }}"
-          git tag -d ${{ github.ref_name }}
-          git tag -a ${{ github.ref_name }} -m "Version ${{ steps.new_version.outputs.substring }}"
-          
-      - name: Push changes
-        uses: ad-m/github-push-action@v0.6.0
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v4.2.1
         with:
-          github_token: ${{ secrets.PAT }}
-          branch: ${{ github.event.repository.default_branch }}
-          force: true
-          tags: true
+          commit-message: "ci: bump version to ${{ steps.new_version.outputs.substring }} from ${{ steps.current_version.outputs.substring }}"
+          branch: bump-version/${{ steps.new_version.outputs.substring }}
+          delete-branch: true
+          title: "ci: bump version to ${{ steps.new_version.outputs.substring }} from ${{ steps.current_version.outputs.substring }}"
+          assignees: kevinanschau
+          reviewers: kevinanschau


### PR DESCRIPTION
Due to possible branch protection, direct pushes to default branches are not allowed. This has led to failed workflows. Hence, instead of pushing directly to the default branch, the  workflow creates a pull request instead.