### PR TITLE
fix(deps): downgrade ros-tooling/actions-ros-ci to 0.2.6 from 0.2.7

### DIFF
--- a/.github/workflows/ros-testing.yml
+++ b/.github/workflows/ros-testing.yml
@@ -58,7 +58,7 @@ jobs:
         run: python3 -m pip install -r requirements-dev.txt
 
       - name: Build and run tests
-        uses: ros-tooling/action-ros-ci@v0.2
+        uses: ros-tooling/action-ros-ci@v0.2.6
         with:
           colcon-defaults: ${{ inputs.colcon-defaults }}
           colcon-extra-args: --event-handlers console_direct+ --executor sequential


### PR DESCRIPTION
Version 0.2.7 of `ros-tooling/action-ros-ci` breaks the workflow. Therefore, decrease to 0.2.6.

- **Please check if the PR fulfills these requirements**
  - [ ] Tests for the changes have been added (for bug fixes/features)


- **What kind of change does this PR introduce?**
  (Bug fix, feature, docs update, ...)


- **What is the current behavior?**


- **What is the new behavior?**
  (if this is a feature change)


- **Does this PR introduce a breaking change?**
  (What changes might users need to make in their application due to this PR?)


- **Other information**

