### PR TITLE
fix(ros-testing)!: require `runs-on` input to workflow call

### DIFF
--- a/.github/workflows/ros-testing.yml
+++ b/.github/workflows/ros-testing.yml
@@ -14,10 +14,13 @@ on:
       ros-distro:
         required: true
         type: string
+      runs-on:
+        required: true
+        type: string
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on }}
 
     steps:
       - name: Checkout the repo


### PR DESCRIPTION
The _Test_ workflow in https://github.com/mantis-tec/argos-supervisor-ros2/pull/64 fails, because it runs on Ubuntu 22.04 and tries to setup ROS 2 Foxy, which is not available as apt packages on Ubuntu 22.04. Previous workflow runs were successful, because the workflow ran on Ubuntu 20.04.